### PR TITLE
added notes from apr 5 meeting

### DIFF
--- a/meeting_notes/20160405_meeting-notes.md
+++ b/meeting_notes/20160405_meeting-notes.md
@@ -1,0 +1,58 @@
+---
+title: Meeting Notes - April 5, 2016
+location: Civic Tech TO - Connection Lab
+attendees: 8
+date: 2016-04-05
+startTime: '19:10'
+---
+
+
+# Agenda
+1. Intros
+2. Problem Definition recap
+3. ~~Website~~    
+4. Roadmap (Events)
+    - Under Gardiner Community Meeting _April 7_
+    - Open Source Circular Economy Days _June 9-13_
+    - Maker Festival _July 9-10_
+    - HOPE, NYC _July 24-26_
+5. ~~Outreach~~
+6. ~~Focus~~
+7. Next Meeting
+
+# Notes
+- Many new attendees! Restructured agenda to make more time for discussion
+
+## Problem Definition: Key Issue & Problem For
+- Worked through comments and notes from our brainstorming docs, key themes in our discussion:
+    - resiliency, sustainable communities
+    - 'democratizing' potential (in quotes)
+    - 'awareness' as not always the right frame to understand invisibility
+    - technology literacy
+- Reframe our language when choosing a key issue (and consider whether some could be collapsed together): _"problematize..."_ or _"lack of..."_
+- Our brainstormed goals of who this is a problem for, or who could be initial interested groups to reach out to, could be expanded to include:
+    - students
+    - shared internet with roommates and in multi-unit places
+- Proposal that we consider adopting an "emergent problem definition"
+
+## Roadmap
+A few events that had been brought up as potential anchors for us to establish goals around were:
+- Under Gardiner Community Meeting _April 7_  [undergardiner.com](http://www.undergardiner.com/)
+    - Project in early stages, decided to wait on future chances to connect
+
+- Open Source Circular Economy Days, Host local event _June 9-13_  [oscedays.org](https://oscedays.org/)
+    - no strong interest in participation
+
+- Maker Festival _July 9-10_  [makerfestival.ca](http://makerfestival.ca/)
+    - definite interest
+    - potential to run hands on workshops/activities
+
+- HOPE, NYC _July 22-24_  [hopeconf.wordpress.com](https://hopeconf.wordpress.com/)
+    - definite interest
+    - potential to connect to other mesh projects
+    - potential to set as a goal for technical reference implementation
+
+# Outcomes
+- Decided to hold a longer planning meeting (3hrs), not during Civic Tech TO's night
+    - Poll for meeting time will be put on the `#torontomesh` channel
+    - Will be selected prior to next Tuesday (April 12) and announced at Civic Tech TO

--- a/meeting_notes/20160405_meeting-notes.md
+++ b/meeting_notes/20160405_meeting-notes.md
@@ -1,15 +1,16 @@
 ---
 title: Meeting Notes - April 5, 2016
-location: Civic Tech TO - Connection Lab
+location: Civic Tech TO, Connection Lab
 attendees: 8
 date: 2016-04-05
-startTime: '19:10'
+startTime: '20:10'
+endTime: '21:00'
 ---
 
-
 # Agenda
+
 1. Intros
-2. Problem Definition recap
+2. Problem Definition recap ([Brainstorm Gdoc](https://docs.google.com/document/d/1XQiqvkuFiTmaVtZcjmwBUfH5cwZdaYYLXHPqWAB1sB0/edit))
 3. ~~Website~~    
 4. Roadmap (Events)
     - Under Gardiner Community Meeting _April 7_
@@ -21,9 +22,11 @@ startTime: '19:10'
 7. Next Meeting
 
 # Notes
+
 - Many new attendees! Restructured agenda to make more time for discussion
 
 ## Problem Definition: Key Issue & Problem For
+
 - Worked through comments and notes from our brainstorming docs, key themes in our discussion:
     - resiliency, sustainable communities
     - 'democratizing' potential (in quotes)
@@ -36,6 +39,7 @@ startTime: '19:10'
 - Proposal that we consider adopting an "emergent problem definition"
 
 ## Roadmap
+
 A few events that had been brought up as potential anchors for us to establish goals around were:
 - Under Gardiner Community Meeting _April 7_  [undergardiner.com](http://www.undergardiner.com/)
     - Project in early stages, decided to wait on future chances to connect
@@ -53,6 +57,7 @@ A few events that had been brought up as potential anchors for us to establish g
     - potential to set as a goal for technical reference implementation
 
 # Outcomes
+
 - Decided to hold a longer planning meeting (3hrs), not during Civic Tech TO's night
-    - Poll for meeting time will be put on the `#torontomesh` channel
-    - Will be selected prior to next Tuesday (April 12) and announced at Civic Tech TO
+    - poll for meeting time will be put on the `#torontomesh` channel
+    - will be selected prior to next Tuesday (April 12) and announced at Civic Tech TO


### PR DESCRIPTION
Just testing this out, think it would be a good idea to have a recap/notes from out meeting public.

Didn't add any identifying info, I think going forward we could:
-ask at a meeting if we could list people as attending publicly
-make clear some notes will be published publicly
-embed images! 
