### PR TITLE
pulled out important meeting notes into readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# meetings
+# Documents
+
+This is the repository where our meeting minutes and other important documents and planning notes will live.
+
+# Getting Involved
+
+We are still in the early stages and would love involvement from more people! Please be in touch by:
+* speaking with us on the `#torontomesh` channel in [CivicTechTO](http://civictech.ca/)'s slack ([get an invite](https://civictechto-slack-invite.herokuapp.com/))
+
+## Project Vision
+
+We are going to build an infrastructure that gives users:
+
+- **agency** to make important decisions about their privacy
+- **autonomy** to access information in an uncontrolled/free manner
+- opportunity to develop **technical literacies**
+- a **resilient** and redundant network
+- open, lower-cost **access** to the World Wide Web
+
+...In order to address the fact that Internet infrastructure is a black-box to most of its users.
+
+## Working Groups
+
+We established initial working groups at the [April 18 meeting](https://github.com/tomeshnet/meetings/blob/master/meeting_notes/20160418_meeting-notes.md).
+
+| Working Group | Members |
+| --- | --- |
+| **Hardware** | Ben, Udit, @dcwalk |
+| **Software** | Ben, Garry |
+| **Use Cases for the Mesh** | Udit, Ben, Garry |
+| **Outreach** | Vince, Ben |
+| **Literacy Development** | Yuri, Matt |
+| **Knowledge Management** | Matt, @dcwalk |
+| **Design** | Matt |
+| **Website** | @dcwalk, Matt, Garry |
+
+## Roadmap
+
+We established an initial roadmap at the [April 18 meeting](https://github.com/tomeshnet/meetings/blob/master/meeting_notes/20160418_meeting-notes.md) and will develop another one in **July** for the remainder of 2016.
+
+| Month | Deadlines |
+| --- | --- |
+| **April** | **April 30**: a proposal for Maker Festival<br />**April 30**: a proposal for Maker Festival |
+| **May** | **end May**: prototype developed for Maker Festival |
+| **June** | **mid June**: prototype _developed_validated for Maker Festival |
+| **July** | **July 9-10**: Maker Festival! (hopefully)<br />**July 22-24**: HOPE Conference<br />**end July**: TOmesh Planning Session |


### PR DESCRIPTION
Took a pass for initial group documentation, thought we could leave it in the readme for now and revisit how we want to handle stuff once the website matures.

Also-- proposing to rename this repository to something else as a result
