### PR TITLE
[WIP] generalize CONTRIBUTING guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,18 +4,21 @@ We love pull requests! Our process for accepting changes has a few steps:
 
 1. If you haven't submitted anything before, and you aren't (yet!) a member of our organization, fork and clone the repo:
 
-        git clone git@github.com:your-username/tomeshnet.github.io.git
-Organization members should clone this repo, instead of working from a fork:
+        git clone git@github.com:<your-username>/<repository-name>.git
 
-        git clone git@github.com:tomeshnet/tomeshnet.github.io.git
+Organization members should clone the upsteam repo, instead of working from a fork:
+
+        git clone git@github.com:tomeshnet/<repository-name>.git
 
 2. Create a new branch for the changes you want to work on. Choose a topic for your branch name that reflects the change:
 
         git checkout -b <branch-name>
 
-3. Create or modify the files with your changes. If you want to show other people work that isn't ready to merge in, commit your changes then [create a pull request (PR)](https://github.com/tomeshnet/tomeshnet.github.io/pull/new/master) with __WIP__ in the title.
+3. Create or modify the files with your changes. If you want to show other people work that isn't ready to merge in, commit your changes then create a pull request (PR) with __WIP__ in the title.
 
-4. Once your changes are ready for final review, commit your changes then [create or modify your PR](https://github.com/tomeshnet/tomeshnet.github.io/pull/new/master).
+        https://github.com/tomeshnet/<repository-name>/pull/new/master
+
+4. Once your changes are ready for final review, commit your changes then create or modify your PR.
 
 5. Allow others sufficient time for review and comments before merging. For big changes, ping another member to check over what you've done. There may be some fixes or adjustments you'll have to make based on feedback.
 


### PR DESCRIPTION
Based on general discussion and comments in [tomesh.net/#3](https://github.com/tomeshnet/tomesh.net/pull/3), the contrib. doc has been moved to documents...

I've tried to generalize the url paths, but is there anything else that should be addressed? @garrying or @benhylau ?
