### PR TITLE
Add code of conduct to documents

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,0 +1,38 @@
+# Toronto Mesh Code of Conduct
+
+## Pledge
+
+Toronto Mesh is dedicated to providing a harassment-free environment for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion or technical skill level.
+
+In order to try and remove obstacles to participation, Toronto Mesh has adopted an explicitly-documented code to communicate our expectations for conduct within the community.
+
+These are adapted from the anti-harassment policy from the [Geek Feminism Wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) and draw inspiration from [No more rock stars: how to stop abuse in tech communities](https://hypatia.ca/2016/06/21/no-more-rock-stars/).
+
+## Standards
+
+We do not tolerate harassment of organization members and participants in any form. Harassment includes, but is not limited to:
+
+* verbal comments that reinforce social structures of domination related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, technical skill level
+* sexual images in public spaces
+* deliberate intimidation, stalking, following
+* harassing photography or recording
+* sustained disruption of talks or other events
+* inappropriate physical contact
+* unwelcome sexual attention
+* advocating for, or encouraging, any of the above behaviour
+
+Sexual language and imagery is not appropriate for any Toronto Mesh organization interactions, including in online spaces.
+
+Participants asked to stop any harassing behavior are expected to comply immediately. Participants violating these rules may be sanctioned or asked to leave, at the discretion of the organizers.
+
+## Scope
+
+This Code of Conduct applies both within project spaces (both event and online spaces) and in public spaces when an individual is representing the Toronto Mesh project or its community.
+
+## Enforcement
+
+If a participant engages in harassing behaviour, the organizers may take any action they deem appropriate, including warning the offender or expulsion from events and online forums.
+
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of Toronto Mesh immediately.
+
+Toronto Mesh organizers will be happy to help participants by providing escorts, contacting local law enforcement, or otherwise assisting those experiencing harassment to feel safe for the duration of an event. We value your participation.

--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -31,8 +31,12 @@ This Code of Conduct applies both within project spaces (both event and online s
 
 ## Enforcement
 
+At events, Toronto Mesh organizers will identify themselves and any incidents can be reported to them directly. Event organizers will be happy to help participants by providing escorts, contacting local law enforcement, or otherwise assisting those experiencing harassment to feel safe for the duration of an event. We value your participation.
+
+In online spaces, Toronto Mesh moderators and administrators have elevated privileges and in order to enforce our standards and pledge.
+
 If a participant engages in harassing behaviour, the organizers may take any action they deem appropriate, including warning the offender or expulsion from events and online forums.
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of Toronto Mesh immediately.
 
-Toronto Mesh organizers will be happy to help participants by providing escorts, contacting local law enforcement, or otherwise assisting those experiencing harassment to feel safe for the duration of an event. We value your participation.
+Those who wish to report a violation but don't feel comfortable talking to the organizers online or at an event can email `coc@tomesh.net`, which is monitored by two individuals on a rotating basis.

--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -33,10 +33,10 @@ This Code of Conduct applies both within project spaces (both event and online s
 
 At events, Toronto Mesh organizers will identify themselves and any incidents can be reported to them directly. Event organizers will be happy to help participants by providing escorts, contacting local law enforcement, or otherwise assisting those experiencing harassment to feel safe for the duration of an event. We value your participation.
 
-In online spaces, Toronto Mesh moderators and administrators have elevated privileges and in order to enforce our standards and pledge.
+In online spaces, Toronto Mesh moderators and administrators have elevated privileges in order to enforce our standards and code of conduct pledge.
 
 If a participant engages in harassing behaviour, the organizers may take any action they deem appropriate, including warning the offender or expulsion from events and online forums.
 
-If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of Toronto Mesh immediately.
+If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a Toronto Mesh moderator or organizer immediately.
 
 Those who wish to report a violation but don't feel comfortable talking to the organizers online or at an event can email `coc@tomesh.net`, which is monitored by two individuals on a rotating basis.

--- a/governance/conduct-guidelines.md
+++ b/governance/conduct-guidelines.md
@@ -1,0 +1,42 @@
+# Code of Conduct Guidelines
+
+Toronto Mesh consensed to actively use our first version of our code of conduct on [November 12, 2016](https://github.com/tomeshnet/documents/blob/master/meeting_notes/20161112_planning-meeting-notes.md)
+
+## Code of Conduct
+
+The Code of Conduct language is in our [documents](https://github.com/tomeshnet/documents/blob/master/CONDUCT.md) github repository and on our website at [tomesh.net/code-of-conduct/](https://tomesh.net/code-of-conduct/https://tomesh.net/code-of-conduct/)
+
+## Enforcement
+
+[Enforcement guidelines](https://github.com/tomeshnet/documents/blob/master/CONDUCT.md#enforcement) are established in the Code of Conduct, with additional details provided below.
+
+### Receiving Reports
+
+(The following is included from [geekfeminism.wikia.com](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports))
+
+If someone reports harassment, ask for a written account of what happened. This should be **kept confidential** to as small a group as reasonably possible, and potentially anonymised by the receiving person before distribution to the closed group. If organizers receive a verbal report, they should themselves write down what they were told as soon as they can.
+
+If the following information is not volunteered in a report, ask for it/include it, but do not pressure anyone:
+
+- Identifying information (name/badge number) of the participant doing the harassing
+- The behavior that was in violation
+- The approximate time of the behavior (if different than the time the report was made)
+- The circumstances surrounding the incident
+- Other people involved in the incident
+
+Further resources:
+
+- [geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports)
+- [wiki.openhatch.org/OpenHatch_event_code_of_conduct/Staff_Procedures_for_Handling_Incidents](http://wiki.openhatch.org/OpenHatch_event_code_of_conduct/Staff_Procedures_for_Handling_Incidents)
+
+### Online Moderation
+
+Online spaces maintained by Toronto Mesh (e.g. [chat.tomesh.net](https://chat.tomesh.net/)) are _also_ covered by our Code of Conduct.
+
+Preliminary guidelines:
+
+- Each publicly-listed [chat.tomesh.net](https://chat.tomesh.net/) room should have more than one moderator
+
+### Email Reporting
+
+Our `coc@tomesh.net` is monitored by two individuals on a rotating basis, new monitors will be determined at our planning meetings which occur roughly every six months.


### PR DESCRIPTION
Please provide feedback. I worked from the source douments for the civic tech code of conduct. 

I think we need to think how to speak to organizers/who is an organizer...
Also @benhylau I believe the language reflects your comments around the spaces that this would be expected to cover. 
